### PR TITLE
docs: replace broken blog link

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Compare a file with an MD5, SHA1, SHA256 or SHA512 hash:
 
 ![screenshot](https://github.com/user-attachments/assets/def91342-5050-4ee2-9090-518be094f9a0)
 
-This program arose from dissatisfaction with the [workarounds required for traditional tools](https://thomask.sdf.org/blog/2019/05/05/techniques-for-verifying-shasums-conveniently.html).
+This program arose from dissatisfaction with the [workarounds required for traditional tools](https://web.archive.org/web/20240101000000*/https://thomask.sdf.org/blog/2019/05/05/techniques-for-verifying-shasums-conveniently.html).
 
 ## Installation
 


### PR DESCRIPTION
Fixes #6

## Summary
- replace the dead README link with an archived copy of the original post

## Testing
- manual README link review